### PR TITLE
fix: add missing i18n entry

### DIFF
--- a/isso/js/app/i18n.js
+++ b/isso/js/app/i18n.js
@@ -55,6 +55,7 @@ define(["app/config", "app/i18n/bg", "app/i18n/cs", "app/i18n/de",
     }
 
     var catalogue = {
+        bg: bg,
         cs: cs,
         de: de,
         el: el,


### PR DESCRIPTION
Fixes an indexing error a user gets when he tries to make the language of isso to `bg`